### PR TITLE
11_1:FIX:herokuへデプロイ

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.3-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.13.3-x86_64-linux)
+      racc (~> 1.4)
     oauth (0.5.8)
     oauth2 (1.4.9)
       faraday (>= 0.17.3, < 3.0)
@@ -235,6 +237,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   better_errors


### PR DESCRIPTION
## 概要
herokuデプロイでエラー下記発生のため
bundle lock --add-platform x86_64-linux and try again.
