### PR TITLE
21_環境変数の読み込みを修正

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
-VUE_APP_API_KEY='AIzaSyCQtHNjxHRZq_H5ledUA-XIQW2-k3lE5cY'
+YOUTUBE_API_KEY='AIzaSyCQtHNjxHRZq_H5ledUA-XIQW2-k3lE5cY'
 API_URL='http://localhost:3000/api/'

--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem 'jbuilder', '~> 2.7'
 # gem 'redis', '~> 4.0'
 # Use Active Model has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
+gem 'dotenv-rails'
 
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,10 @@ GEM
     debug_inspector (1.1.0)
     declarative (0.0.20)
     diff-lcs (1.5.0)
+    dotenv (2.7.6)
+    dotenv-rails (2.7.6)
+      dotenv (= 2.7.6)
+      railties (>= 3.2)
     erubi (1.10.0)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
@@ -330,6 +334,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.4)
   byebug
   capybara
+  dotenv-rails
   factory_bot_rails
   faker
   foreman

--- a/app/javascript/pages/list/conponents/youtube/SearchList.vue
+++ b/app/javascript/pages/list/conponents/youtube/SearchList.vue
@@ -41,7 +41,7 @@ export default {
         type: "video",
         maxResults: "10",
         channelId: this.channelid,
-        key: process.env.VUE_APP_API_KEY,
+        key: process.env.YOUTUBE_API_KEY,
       },
       selectid: ""
     };

--- a/app/javascript/store/modules/video.js
+++ b/app/javascript/store/modules/video.js
@@ -6,7 +6,7 @@ const actions = {
       params: {
         part: 'snippet',
         playlistId: list.playlistid,
-        key: process.env.VUE_APP_API_KEY,
+        key: process.env.YOUTUBE_API_KEY,
       }
     });
   }

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,6 +1,7 @@
 const { environment } = require('@rails/webpacker')
 const { VueLoaderPlugin } = require('vue-loader')
 
+
 environment.plugins.prepend(
      'VueLoaderPlugin',
      new VueLoaderPlugin()
@@ -20,6 +21,19 @@ environment.plugins.prepend(
         __VUE_OPTIONS_API__: true,
         __VUE_PROD_DEVTOOLS__: true
     })
+)
+const webpack = require('webpack')
+const dotenv = require('dotenv')
+const dotenvFiles = [
+    '.env'
+]
+dotenvFiles.forEach((dotenvFile) => {
+    dotenv.config({ path: dotenvFile, silent: true })
+})
+environment.plugins.prepend('Environment',
+    new webpack.EnvironmentPlugin(
+        JSON.parse(JSON.stringify(process.env))
+    )
 )
 
 module.exports = environment


### PR DESCRIPTION
## 概要
### 課題
サーバーを起動したときに、環境変数が取得できていない
### 解決方法
gem 'dotenv-rails'を追加し、設定を行う

## 確認方法
サーバーを起動し、問題なく環境変数が取得できることを確認する。

## チェックリスト
- [x] Lint のチェックをパスした
## コメント
foremanを用いてサーバーを起動した場合、環境変数を取得できていたため発見が遅れました。
今回の修正で、foreman、別々でサーバーを起動した時どちらも読み込みが可能になっております。

close #43 