### PR TITLE
修正_profileがnilでバリデーションエラーが起きる

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -23,6 +23,6 @@ class Api::UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:email, :password, :password_confirmation, :name, :channelid, :avatar)
+    params.require(:user).permit(:email, :password, :password_confirmation, :name, :channelid, :avatar, :profile)
   end
 end

--- a/app/javascript/pages/register/index.vue
+++ b/app/javascript/pages/register/index.vue
@@ -165,6 +165,7 @@ export default {
         password: '',
         password_confirmation: '',
         terms: false,
+        profile: '',
     }
     const schema = object({
       name: 


### PR DESCRIPTION
## 概要
ユーザーのprofileカラムがnilだったときに、バリデーションエラーが発生
<img width="705" alt="スクリーンショット 2022-05-14 15 16 58" src="https://user-images.githubusercontent.com/93305003/168413422-f0fbea9f-f52b-4742-8d94-a78b93f5c111.png">

## 対処方法
ユーザー登録時にをnilではなく""で登録するように修正
